### PR TITLE
RippleEffect color

### DIFF
--- a/common_compose/src/main/java/com/zywczas/commoncompose/components/HorizontalListItemDivider.kt
+++ b/common_compose/src/main/java/com/zywczas/commoncompose/components/HorizontalListItemDivider.kt
@@ -1,12 +1,12 @@
 package com.zywczas.commoncompose.components
 
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import com.zywczas.commoncompose.theme.PrimaryColor
 
 @Composable
 fun HorizontalListItemDivider() {
     HorizontalDivider(
-        color = MaterialTheme.colorScheme.primary
+        color = PrimaryColor
     )
 }

--- a/common_compose/src/main/java/com/zywczas/commoncompose/components/ListHeader.kt
+++ b/common_compose/src/main/java/com/zywczas/commoncompose/components/ListHeader.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.zywczas.commoncompose.theme.PreviewTheme
+import com.zywczas.commoncompose.theme.PrimaryColor
 import com.zywczas.commoncompose.theme.Spacing
 
 @Composable
@@ -20,7 +21,7 @@ fun ListHeader(text: String) {
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.primary),
+            .background(PrimaryColor),
     ) {
         Text(
             text = text,

--- a/common_compose/src/main/java/com/zywczas/commoncompose/components/Toolbar.kt
+++ b/common_compose/src/main/java/com/zywczas/commoncompose/components/Toolbar.kt
@@ -5,13 +5,13 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.zywczas.commoncompose.theme.PreviewTheme
+import com.zywczas.commoncompose.theme.PrimaryColor
 import com.zywczas.commonutil.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -30,7 +30,7 @@ fun Toolbar(
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(R.string.content_description_navigate_back),
-                        tint = MaterialTheme.colorScheme.primary
+                        tint = PrimaryColor
                     )
                 }
             }

--- a/common_compose/src/main/java/com/zywczas/commoncompose/theme/Color.kt
+++ b/common_compose/src/main/java/com/zywczas/commoncompose/theme/Color.kt
@@ -10,3 +10,4 @@ val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
 
 val BlueGrotto = Color(0xFF03A9F4)
+val PrimaryColor = BlueGrotto

--- a/common_compose/src/main/java/com/zywczas/commoncompose/theme/Theme.kt
+++ b/common_compose/src/main/java/com/zywczas/commoncompose/theme/Theme.kt
@@ -1,15 +1,15 @@
 package com.zywczas.commoncompose.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -27,28 +27,26 @@ private val LightColorScheme = lightColorScheme(
     tertiary = Pink40
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = typography,
-        content = content
-    )
+    CompositionLocalProvider(
+        LocalRippleConfiguration provides RippleConfiguration(PrimaryColor)
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = typography,
+            content = content
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
Deleted dynamic colors from AppTheme as they override app colors.

Added RippleEffect color via LocalRippleConfiguration.

Created PrimaryColor as MaterialTheme.colorSchema can be used only inside composable functions and RippleConfiguration is not Composable. So to unify approach, PrimaryColor will be used instead of MaterialTheme, across the app.