### PR TITLE
fix: Message not appearing on screen init

### DIFF
--- a/common_utils/src/commonMain/kotlin/com/zywczas/commonutils/BaseViewModel.kt
+++ b/common_utils/src/commonMain/kotlin/com/zywczas/commonutils/BaseViewModel.kt
@@ -1,15 +1,16 @@
 package com.zywczas.commonutils
 
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 abstract class BaseViewModel : ViewModel() {
 
-    private val _announcement = MutableSharedFlow<String>()
-    val announcement: SharedFlow<String> = _announcement
+    private val _announcement = Channel<String>(capacity = Channel.BUFFERED)
+    val announcement: Flow<String> = _announcement.receiveAsFlow()
 
     suspend fun showError(msg: String) {
-        _announcement.emit(msg)
+        _announcement.send(msg)
     }
 }


### PR DESCRIPTION
Problem:
When SharedFlow emitted an element before any collector was created (e.g. a screen reading the flow), then this element was omitted.

Solution:
Change SharedFlow to Channel(Channel.BUFFERED) - Buffered Channel will keep an element until it is collected and when it's collected then it disappears from the channel, so there won't be a repeated message on configuration change.