### PR TITLE
fix: Snackbar under bottom nav bar

### DIFF
--- a/common_compose/src/commonMain/kotlin/com/zywczas/commoncompose/components/Snackbar.kt
+++ b/common_compose/src/commonMain/kotlin/com/zywczas/commoncompose/components/Snackbar.kt
@@ -1,6 +1,7 @@
 package com.zywczas.commoncompose.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -9,11 +10,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun Snackbar(hostState: SnackbarHostState) {
+fun Snackbar(hostState: SnackbarHostState, withBottomBarInsetSpacer: Boolean = false) {
     Box(Modifier.fillMaxSize()) {
-        SnackbarHost(
-            hostState,
-            modifier = Modifier.align(Alignment.BottomCenter)
-        )
+        Column(modifier = Modifier.align(Alignment.BottomCenter)) {
+            SnackbarHost(hostState)
+
+            if (withBottomBarInsetSpacer) {
+                BottomBarInsetSpacer()
+            }
+        }
     }
 }

--- a/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
+++ b/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
@@ -78,7 +78,7 @@ fun PlaceForecastScreen(location: SelectedLocation, goBackAction: OnClick) {
         )
     }
 
-    Snackbar(snackbarHostState) //todo snackbar is shown under bottom bar atm
+    Snackbar(snackbarHostState, withBottomBarInsetSpacer = true)
 
     LaunchedEffect(Unit) {
         viewModel.announcement.collectLatest { text ->

--- a/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/SearchCityScreen.kt
+++ b/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/SearchCityScreen.kt
@@ -45,7 +45,7 @@ fun SearchLocationScreen(onLocationClick: (SelectedLocation) -> Unit) {
         onSearchTextChanged = viewModel::onSearchTextChanged
     )
 
-    Snackbar(snackbarHostState)
+    Snackbar(snackbarHostState, withBottomBarInsetSpacer = true)
 
     LaunchedEffect(Unit) {
         viewModel.announcement.collectLatest { text ->


### PR DESCRIPTION
Problem:
Snackbar is shown under bottom nav bar so it cannot be read.

Solution:
Added BottomBarInsetSpacer to lift the Snackbar above height of bottom bar.