### PR TITLE
fix: Toolbar text cut at the bottom

### DIFF
--- a/common_compose/src/commonMain/kotlin/com/zywczas/commoncompose/components/Toolbar.kt
+++ b/common_compose/src/commonMain/kotlin/com/zywczas/commoncompose/components/Toolbar.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextOverflow
 import com.zywczas.commoncompose.theme.Color
 import com.zywczas.commoncompose.theme.Theme
 import com.zywczas.weather.resources.commonutils.Res
@@ -30,7 +31,9 @@ fun Toolbar(
         title = {
             Text(
                 text = title,
-                style = textStyle
+                style = textStyle,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         },
         navigationIcon = onBackClick?.let {

--- a/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
+++ b/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
@@ -95,7 +95,7 @@ private fun PlaceForecastScreen(
 ) {
     Column {
         Toolbar(
-            title = viewEntity.toolbarTitle, // todo it cuts text from bottom as is too long, should ellipsize text
+            title = viewEntity.toolbarTitle,
             onBackClick = goBackAction
         )
 


### PR DESCRIPTION
Problem:
When Toolbar had text of 3 lines, then bottom of third line was partially cut as it couldn't fit the size of the toolbar.

Solution:
Set max lines in toolbar to only 2 and if text is longer then it will ellipsize.