### PR TITLE
Performance improvements of Lists

### DIFF
--- a/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
+++ b/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/PlaceForecastScreen.kt
@@ -169,7 +169,10 @@ private fun HourlyForecast(
                         Spacer(Modifier.width(Spacing.screenBorder))
                     }
 
-                    itemsIndexed(viewEntity) { index, item ->
+                    itemsIndexed(
+                        items = viewEntity,
+                        key = { index, item -> item.hashCode() }
+                    ) { index, item ->
                         HourlyListItem(item)
 
                         if (index < viewEntity.lastIndex) {

--- a/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/SearchCityScreen.kt
+++ b/feature_forecast_place/src/commonMain/kotlin/com/zywczas/featureforecastplace/screens/SearchCityScreen.kt
@@ -71,7 +71,10 @@ private fun SearchLocationScreen(
         Spacer(Modifier.height(Spacing.screenComponentsVertical))
 
         LazyColumn {
-            itemsIndexed(locations) { index, location ->
+            itemsIndexed(
+                items = locations,
+                key = { index, item -> item.hashCode() }
+            ) { index, location ->
                 when (location) {
                     is SearchListItem.Header -> ListHeader(location.text)
                     is SearchListItem.Location -> {


### PR DESCRIPTION
Changed "mutableStateOf<List>" to "mutableStateListOf" for quicker recomposition. With mutableStateListOf recomposition happens only to an element which was actually changed, the rest stays the same if hashCode key is used. Marked ViewModels as @Stable for avoidance of unnecessary recompositions.